### PR TITLE
Fix bravia reference error in demo.js

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,4 +1,4 @@
-
+var bravia = require('./lib');
 // Accepts two parameters: IP and PSKKey
 
 bravia('192.168.1.100', '0000', function(client) {


### PR DESCRIPTION
This fixes
`
ReferenceError: bravia is not defined
    at Object.<anonymous> (/root/bravia/demo.js:4:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
`